### PR TITLE
Allow seleniumProxy to use arbitrary port number from ProxyServer

### DIFF
--- a/src/main/java/org/browsermob/proxy/ProxyManager.java
+++ b/src/main/java/org/browsermob/proxy/ProxyManager.java
@@ -2,8 +2,8 @@ package org.browsermob.proxy;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.Provider;
 
-import javax.inject.Provider;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/main/java/org/browsermob/proxy/ProxyServer.java
+++ b/src/main/java/org/browsermob/proxy/ProxyServer.java
@@ -58,8 +58,9 @@ public class ProxyServer {
     public org.openqa.selenium.Proxy seleniumProxy() {
         Proxy proxy = new Proxy();
         proxy.setProxyType(Proxy.ProxyType.MANUAL);
-        proxy.setHttpProxy("localhost:4444");
-        proxy.setSslProxy("localhost:4444");
+        String proxyStr = String.format("localhost:%d", getPort());
+        proxy.setHttpProxy(proxyStr);
+        proxy.setSslProxy(proxyStr);
 
         return proxy;
     }


### PR DESCRIPTION
- Allow seleniumProxy to use arbitrary port number from ProxyServer
- Fixed ProxyManager dependency for guice Provider
