### PR TITLE
Bug fix on the HAR Connect timings.

### DIFF
--- a/src/main/java/org/browsermob/proxy/http/RequestInfo.java
+++ b/src/main/java/org/browsermob/proxy/http/RequestInfo.java
@@ -218,7 +218,7 @@ public class RequestInfo {
 
         long connect = 0;
         if (this.connect != null) {
-            receive = this.connect;
+            connect = this.connect;
         }
 
         return new HarTimings(blocked, dns, connect, send, wait, receive);


### PR DESCRIPTION
HAR receive timings were being set to the connect timings. This left all the HAR Connect timings at 0.
