### PR TITLE
Starting proxy servers on custom ports + Refactor of custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Once that is done, a new proxy will be available on the port returned. All you h
   - downstreamKbps - Sets the downstream kbps
   - upstreamKbps - Sets the upstream kbps
   - latency - Add the given latency to each HTTP request
- - PUT /proxy/[port]/headers - Set and override HTTP Request headers. For example setting a custom User-Agent.
-  - Accepts an arbitrary set of paramaters, these are treated as name:value pairs for setting the headers.
-  - NOTE: Currently, custom header names (not values) should be sent with underscores (\_) used in the place of hyphens (-). eg. "User_Agent" instead of User-Agent. This will give the expected behavior.
+ - PUT /proxy/[port]/addHeader - Set and override HTTP Request headers. For example setting a custom User-Agent.
+  - header - "key:value" pair for the header to add.
+   - eg "header=User-Agent:MyBrowser"
 
 For example, once you've started the proxy you can create a new HAR to start recording data like so:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Once started, there won't be an actual proxy running until you create a new prox
     [~]$ curl -X POST http://localhost:9090/proxy
     {"port":9091}
 
+or optionally specify your own port:
+
+    [~]$ curl -X POST -d 'port=9099' http://localhost:9090/proxy
+    {"port":9099}
+
 Once that is done, a new proxy will be available on the port returned. All you have to do is point a browser to that proxy on that port and you should be able to browser the internet. The following additional APIs will then be available:
 
  - PUT /proxy/[port]/har - creates a new HAR attached to the proxy and returns the HAR content if there was a previous HAR. Supports the following parameters:

--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ Once that is done, a new proxy will be available on the port returned. All you h
   - downstreamKbps - Sets the downstream kbps
   - upstreamKbps - Sets the upstream kbps
   - latency - Add the given latency to each HTTP request
- - PUT /proxy/[port]/addHeader - Set and override HTTP Request headers. For example setting a custom User-Agent.
-  - header - "key:value" pair for the header to add.
-   - eg "header=User-Agent:MyBrowser"
+ - POST /proxy/[port]/headers - Set and override HTTP Request headers. For example setting a custom User-Agent.
+  - POST data should be json encoded set of headers (not url-encoded)
 
 For example, once you've started the proxy you can create a new HAR to start recording data like so:
 

--- a/src/main/java/org/browsermob/proxy/ProxyManager.java
+++ b/src/main/java/org/browsermob/proxy/ProxyManager.java
@@ -20,6 +20,15 @@ public class ProxyManager {
         this.proxyServerProvider = proxyServerProvider;
     }
 
+    public ProxyServer create(Map<String, String> options, int port) throws Exception {
+        ProxyServer proxy = proxyServerProvider.get();
+        proxy.setPort(port);
+        proxy.start();
+        proxy.setOptions(options);
+        proxies.put(port, proxy);
+        return proxy;
+    }
+
     public ProxyServer create(Map<String, String> options) throws Exception {
         int port = portCounter.incrementAndGet();
         ProxyServer proxy = proxyServerProvider.get();

--- a/src/main/java/org/browsermob/proxy/ProxyServer.java
+++ b/src/main/java/org/browsermob/proxy/ProxyServer.java
@@ -180,6 +180,10 @@ public class ProxyServer {
         client.whitelistRequests(patterns, responseCode);
     }
 
+    public void addHeader(String name, String value) {
+        client.addHeader(name, value);
+    }
+
     public void setCaptureHeaders(boolean captureHeaders) {
         client.setCaptureHeaders(captureHeaders);
     }

--- a/src/main/java/org/browsermob/proxy/bricks/ProxyResource.java
+++ b/src/main/java/org/browsermob/proxy/bricks/ProxyResource.java
@@ -43,9 +43,15 @@ public class ProxyResource {
             options.put("httpProxy", httpProxy);
         }
 
-        ProxyServer proxy = proxyManager.create(options);
-        int port = proxy.getPort();
-
+        String paramPort = request.param("port");
+        int port = 0;
+        if (paramPort != null) {
+            port = Integer.parseInt(paramPort);
+            ProxyServer proxy = proxyManager.create(options, port);
+        } else {
+            ProxyServer proxy = proxyManager.create(options);
+            port = proxy.getPort();
+        }
         return Reply.with(new ProxyDescriptor(port)).as(Json.class);
     }
 

--- a/src/main/java/org/browsermob/proxy/bricks/ProxyResource.java
+++ b/src/main/java/org/browsermob/proxy/bricks/ProxyResource.java
@@ -19,6 +19,7 @@ import org.apache.http.protocol.HttpContext;
 import org.apache.http.HttpRequest;
 
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.Set;
 import java.util.List;
 
@@ -113,17 +114,17 @@ public class ProxyResource {
         return Reply.saying().ok();
     }
 
-    @Put
-    @At("/:port/addHeader")
-    public Reply<?> addHeader(@Named("port") int port, Request request) {
+    @Post
+    @At("/:port/headers")
+    public Reply<?> updateHeaders(@Named("port") int port, Request request) {
         ProxyServer proxy = proxyManager.get(port);
-        String header = request.param("header");
-        String[] temp = header.split(":", 2);
-        String name = temp[0];
-        String value = temp[1];
-        proxy.addHeader(name, value);
+        Map<String, String> headers = request.read(Map.class).as(Json.class);
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            proxy.addHeader(key, value);
+        }
         return Reply.saying().ok();
-    }
 
     @Put
     @At("/:port/limit")

--- a/src/main/java/org/browsermob/proxy/bricks/ProxyResource.java
+++ b/src/main/java/org/browsermob/proxy/bricks/ProxyResource.java
@@ -1,6 +1,5 @@
 package org.browsermob.proxy.bricks;
 
-import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.google.sitebricks.At;
@@ -20,7 +19,6 @@ import org.apache.http.protocol.HttpContext;
 import org.apache.http.HttpRequest;
 
 import java.util.Hashtable;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.List;
 
@@ -116,24 +114,14 @@ public class ProxyResource {
     }
 
     @Put
-    @At("/:port/headers")
-    public Reply<?> headers(@Named("port") int port, Request request) {
+    @At("/:port/addHeader")
+    public Reply<?> addHeader(@Named("port") int port, Request request) {
         ProxyServer proxy = proxyManager.get(port);
-        final Multimap headers = request.params();
-        proxy.addRequestInterceptor(new HttpRequestInterceptor() {
-            @Override
-            public void process(HttpRequest request, HttpContext context) {
-                Set keySet = headers.keySet();
-                Iterator keyIterator = keySet.iterator();
-                while (keyIterator.hasNext() ) {
-                    String key = (String) keyIterator.next();
-                    List values = (List) headers.get(key);
-                    String value = (String) values.get(0);
-                    request.removeHeaders(key);
-                    request.addHeader(key, value);
-                }
-            }
-        });
+        String header = request.param("header");
+        String[] temp = header.split(":", 2);
+        String name = temp[0];
+        String value = temp[1];
+        proxy.addHeader(name, value);
         return Reply.saying().ok();
     }
 

--- a/src/main/java/org/browsermob/proxy/http/BrowserMobHttpClient.java
+++ b/src/main/java/org/browsermob/proxy/http/BrowserMobHttpClient.java
@@ -9,6 +9,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -109,6 +111,7 @@ public class BrowserMobHttpClient {
     private List<BlacklistEntry> blacklistEntries = null;
     private WhitelistEntry whitelistEntry = null;
     private List<RewriteRule> rewriteRules = new CopyOnWriteArrayList<RewriteRule>();
+    private HashMap<String, String> additionalHeaders = new HashMap();
     private int requestTimeout;
     private AtomicBoolean allowNewRequests = new AtomicBoolean(true);
     private BrowserMobHostNameResolver hostNameResolver;
@@ -469,6 +472,17 @@ public class BrowserMobHttpClient {
                 }
             }
         }
+
+        if (!additionalHeaders.isEmpty()) {
+            // Set the additional headers
+            for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+                method.removeHeaders(key);
+                method.addHeader(key, value);
+            }
+        }
+
 
         String charSet = "UTF-8";
         String responseBody = null;
@@ -902,6 +916,10 @@ public class BrowserMobHttpClient {
 
     public void whitelistRequests(String[] patterns, int responseCode) {
         whitelistEntry = new WhitelistEntry(patterns, responseCode);
+    }
+
+    public void addHeader(String name, String value) {
+        additionalHeaders.put(name, value);
     }
 
     public void prepareForBrowser() {


### PR DESCRIPTION
Added support for creating proxies which run on a custom port. Also supported and documented in the REST API. This way you can programmatically bind to a port and see if it's free before attempting to open a Proxy on that port.

Perhaps default behaviour should be to attempt to ask the OS for a free port rather than current behaviour of incrementing a counter? 

-- See comment below for details on the new implementation of the custom headers
