### PR TITLE
SimulatedSocketFactory.java uses GetHostString(), a Java 7 function

### DIFF
--- a/src/main/java/org/browsermob/proxy/http/SimulatedSocketFactory.java
+++ b/src/main/java/org/browsermob/proxy/http/SimulatedSocketFactory.java
@@ -115,7 +115,7 @@ public class SimulatedSocketFactory implements SchemeSocketFactory {
         //TODO: this has to be changed to HttpInetSocketAddress once we upgrade to 4.2.1
         InetSocketAddress remoteAddr = remoteAddress;
         if (this.hostNameResolver != null) {
-            remoteAddr = new InetSocketAddress(this.hostNameResolver.resolve(remoteAddress.getHostString()), remoteAddress.getPort());
+            remoteAddr = new InetSocketAddress(this.hostNameResolver.resolve(remoteAddress.getHostName()), remoteAddress.getPort());
         }
 
         int timeout = HttpConnectionParams.getConnectionTimeout(params);


### PR DESCRIPTION
GetHostString() is a Java 7 method, GetHostName() is backwards-compatible, though it doesn't avoid DNS lookups like the new method.
