### PR TITLE
Don't null out the SSL relay nuke directory, otherwise we'll never cleanup the SSL support files.

### DIFF
--- a/src/main/java/org/browsermob/proxy/BrowserMobProxyHandler.java
+++ b/src/main/java/org/browsermob/proxy/BrowserMobProxyHandler.java
@@ -95,7 +95,6 @@ public class BrowserMobProxyHandler extends SeleniumProxyHandler {
     @Override
     protected SslRelay getSslRelayOrCreateNew(URI uri, InetAddrPort addrPort, HttpServer server) throws Exception {
         SslRelay relay = super.getSslRelayOrCreateNew(uri, addrPort, server);
-        relay.setNukeDirOrFile(null);
 
         synchronized (sslRelays) {
             sslRelays.add(relay);


### PR DESCRIPTION
Fixes #108: SSL support directories not being cleaned up.

@lightbody if you could take a look at this, it'd be much appreciated.  It looks like you explicitly nulled out this directory in a commit about a year ago.  I couldn't garner from context why though.
