### PR TITLE
As a general purpose proxy, we shouldn't limit the number of connections to emulate Firefox 3.

### DIFF
--- a/src/main/java/org/browsermob/proxy/http/BrowserMobHttpClient.java
+++ b/src/main/java/org/browsermob/proxy/http/BrowserMobHttpClient.java
@@ -141,10 +141,6 @@ public class BrowserMobHttpClient {
             }
         };
 
-        // MOB-338: 30 total connections and 6 connections per host matches the behavior in Firefox 3
-        httpClientConnMgr.setMaxTotal(30);
-        httpClientConnMgr.setDefaultMaxPerRoute(6);
-
         httpClient = new DefaultHttpClient(httpClientConnMgr) {
             @Override
             protected HttpRequestExecutor createRequestExecutor() {


### PR DESCRIPTION
I think this one is pretty safe, but I wanted another set of eyes before I blindly merged it.
